### PR TITLE
Conmurph concrete interface name validation fix

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -182,9 +182,9 @@ variable "concrete_devices" {
 
   validation {
     condition = alltrue(flatten([
-      for c in var.concrete_devices : [for i in coalesce(c.interfaces, []) : can(regex("^[a-zA-Z0-9_.-]{0,64}$", i.name))]
+      for c in var.concrete_devices : [for i in coalesce(c.interfaces, []) : can(regex("^[a-zA-Z0-9\\!#$%()*,-./:;@ _{|}~?&+]{0,256}$", i.name))]
     ]))
-    error_message = "`interfaces.name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    error_message = "`interface`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`,`\\`,`!`,`#`,`$`,`%`,`(`,`)`,`*`,`,`,`-`,`.`,`/`,`:`,`;`,`@`,` `,`_`,`{`,`|`,`}`,`~`,`?`,`&`,`+`. Maximum characters: 256."
   }
 
   validation {
@@ -294,8 +294,8 @@ variable "logical_interfaces" {
 
   validation {
     condition = alltrue(flatten([
-      for l in var.logical_interfaces : [for c in coalesce(l.concrete_interfaces, []) : can(regex("^[a-zA-Z0-9_.-]{0,64}$", c.interface))]
+      for l in var.logical_interfaces : [for c in coalesce(l.concrete_interfaces, []) : can(regex("^[a-zA-Z0-9\\!#$%()*,-./:;@ _{|}~?&+]{0,256}$", c.interface))]
     ]))
-    error_message = "`interface`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    error_message = "`interface`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`,`\\`,`!`,`#`,`$`,`%`,`(`,`)`,`*`,`,`,`-`,`.`,`/`,`:`,`;`,`@`,` `,`_`,`{`,`|`,`}`,`~`,`?`,`&`,`+`. Maximum characters: 256."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -184,7 +184,7 @@ variable "concrete_devices" {
     condition = alltrue(flatten([
       for c in var.concrete_devices : [for i in coalesce(c.interfaces, []) : can(regex("^[a-zA-Z0-9\\!#$%()*,-./:;@ _{|}~?&+]{0,256}$", i.name))]
     ]))
-    error_message = "`interfaces.name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`,`\\`,`!`,`#`,`$`,`%`,`(`,`)`,`*`,`,`,`-`,`.`,`/`,`:`,`;`,`@`,` `,`_`,`{`,`|`,`}`,`~`,`?`,`&`,`+`. Maximum characters: 256."
+    error_message = "`interfaces.name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, `}`, `~`, `?`, `&`, `+`. Maximum characters: 256."
   }
 
   validation {
@@ -296,6 +296,6 @@ variable "logical_interfaces" {
     condition = alltrue(flatten([
       for l in var.logical_interfaces : [for c in coalesce(l.concrete_interfaces, []) : can(regex("^[a-zA-Z0-9\\!#$%()*,-./:;@ _{|}~?&+]{0,256}$", c.interface))]
     ]))
-    error_message = "`interface`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`,`\\`,`!`,`#`,`$`,`%`,`(`,`)`,`*`,`,`,`-`,`.`,`/`,`:`,`;`,`@`,` `,`_`,`{`,`|`,`}`,`~`,`?`,`&`,`+`. Maximum characters: 256."
+    error_message = "`interface`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, `}`, `~`, `?`, `&`, `+`. Maximum characters: 256."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -184,7 +184,7 @@ variable "concrete_devices" {
     condition = alltrue(flatten([
       for c in var.concrete_devices : [for i in coalesce(c.interfaces, []) : can(regex("^[a-zA-Z0-9\\!#$%()*,-./:;@ _{|}~?&+]{0,256}$", i.name))]
     ]))
-    error_message = "`interface`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`,`\\`,`!`,`#`,`$`,`%`,`(`,`)`,`*`,`,`,`-`,`.`,`/`,`:`,`;`,`@`,` `,`_`,`{`,`|`,`}`,`~`,`?`,`&`,`+`. Maximum characters: 256."
+    error_message = "`interfaces.name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`,`\\`,`!`,`#`,`$`,`%`,`(`,`)`,`*`,`,`,`-`,`.`,`/`,`:`,`;`,`@`,` `,`_`,`{`,`|`,`}`,`~`,`?`,`&`,`+`. Maximum characters: 256."
   }
 
   validation {


### PR DESCRIPTION
It seems like the validation rule for the concrete interface name allows for additional characters. It should allow examples such as GigabitEthernet0/1 

https://pubhub.devnetcloud.com/media/apic-mim-ref-311/docs/

![image](https://github.com/netascode/terraform-aci-l4l7-device/assets/22744831/5bdaa381-adec-4472-bad9-b372e1f5e400)

![image](https://github.com/netascode/terraform-aci-l4l7-device/assets/22744831/c16b50b3-7334-4f88-8e14-7cf5fd6850c8)

